### PR TITLE
fix: add rule to handle different number formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "work-hours-price-converter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chrome extension to convert product prices on any supported e-commerce website into the number of work hours needed to afford them, based on your hourly wage.",
   "devDependencies": {
     "@types/chrome": "^0.1.3",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Work Hours Price Converter",
   "description": "Convert product prices into the work hours required based on your hourly wage.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icons": {
     "16": "assets/icon16.png",
     "48": "assets/icon48.png",


### PR DESCRIPTION
There was an issue with thousand values in Amazon parser.